### PR TITLE
Add support for jfif and 3gpp formats

### DIFF
--- a/Application/FileConverter/Helpers.cs
+++ b/Application/FileConverter/Helpers.cs
@@ -51,6 +51,7 @@ namespace FileConverter
                     return InputCategoryNames.Audio;
 
                 case "3gp":
+                case "3gpp":
                 case "avi":
                 case "bik":
                 case "flv":
@@ -69,6 +70,7 @@ namespace FileConverter
                 case "bmp":
                 case "exr":
                 case "ico":
+                case "jfif":
                 case "jpg":
                 case "jpeg":
                 case "png":


### PR DESCRIPTION
On the github page of the original file converter, many people requested for jfif and 3gpp formats to be supported. As the original creator is inactive, there is no point in asking them to do this, so i hope you will consider adding this change (and i hope it works, due to technical difficulties i am unable to test it)